### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@
 
 # Open Source at Oracle
 
-Oracle is the purveyor of the industry’s most widely adopted open source technologies, such as [Java](https://openjdk.java.net/) and [MySQL](https://www.mysql.com/), and one of the founding members of the [Linux Foundation](https://linuxfoundation.org/), the [Eclipse Foundation](https://www.eclipse.org/), and the [Java Community Process](https://jcp.org/en/home/index).
+Oracle is the purveyor of the industry’s most widely adopted open source technologies, such as [Java](https://openjdk.org/) and [MySQL](https://www.mysql.com/), and one of the founding members of the [Linux Foundation](https://linuxfoundation.org/), the [Eclipse Foundation](https://www.eclipse.org/), and the [Java Community Process](https://jcp.org/en/home/index).
 
 But what has guided us along the way?
 


### PR DESCRIPTION
Hey all,

please review this small PR that updates the domain for the OpenJDK project from `openjdk.java.net` to `openjdk.org`. The OpenJDK project changed its domain to `openjdk.org` in [June, 2022](https://mail.openjdk.org/pipermail/announce/2022-June/000321.html).

Thanks!
Erik